### PR TITLE
Add non-existent elements when calling setCount(_, for:)

### DIFF
--- a/CountedSet/CountedSet.swift
+++ b/CountedSet/CountedSet.swift
@@ -55,12 +55,15 @@ public struct CountedSet<Element : Hashable> : ExpressibleByArrayLiteral {
         return count(for: member)
     }
     
-    @discardableResult public mutating func setCount(_ count: Int, for element: Element) -> Bool {
+    public mutating func setCount(_ count: Int, for element: Element) {
         precondition(count >= 0, "Count has to be positive")
-        guard contains(element) else { return false }
+        if count > 0 && !contains(element) {
+            backing.insert(element)
+        }
         countByElement[element] = count
-        if count <= 0 { backing.remove(element) }
-        return true
+        if count <= 0 {
+            backing.remove(element)
+        }
     }
 
     public func mostFrequent() -> ElementWithCount? {

--- a/CountedSetTests/CountedSetTests.swift
+++ b/CountedSetTests/CountedSetTests.swift
@@ -247,34 +247,30 @@ class CountedSetTests: XCTestCase {
         XCTAssertEqual(sut["Baz"], 0)
     }
     
-    func testThatItReturnsFalseWhenSettingCountForNonContainedElement() {
+    func testThatItAddsANonExistentElementWhenSettingCount() {
         // given
         sut = CountedSet(arrayLiteral: "Foo", "Bar")
+        // when
+        sut.setCount(2, for: "Baz")
         // then
-        XCTAssertFalse(sut.setCount(2, for: "Baz"))
-    }
-    
-    func testThatItReturnsTrueWhenSettingCountForContainedElement() {
-        // given
-        sut = CountedSet(arrayLiteral: "Foo", "Bar")
-        // then
-        XCTAssertTrue(sut.setCount(2, for: "Foo"))
+        XCTAssert(sut.contains("Baz"))
+        XCTAssertEqual(sut.count(for: "Baz"), 2)
     }
     
     func testThatItSetsTheNewCountWhenSettingCountForContainedElement() {
         // given
         sut = CountedSet(arrayLiteral: "Foo", "Bar")
         // when
-        XCTAssertTrue(sut.setCount(2, for: "Foo"))
+        sut.setCount(3, for: "Foo")
         // then
-        XCTAssertEqual(sut.count(for: "Foo"), 2)
+        XCTAssertEqual(sut.count(for: "Foo"), 3)
     }
     
     func testThatItRemovesElementFrombackingStoreWhenSettingCountForContainedElementToZero() {
         // given
         sut = CountedSet(arrayLiteral: "Foo", "Bar")
         // when
-        XCTAssertTrue(sut.setCount(0, for: "Foo"))
+        sut.setCount(0, for: "Foo")
         // then
         XCTAssertFalse(sut.contains("Foo"))
         XCTAssertEqual(sut.count(for: "Foo"), 0)


### PR DESCRIPTION
# What's in this PR?

* The behaviour before was a bit odd in my opinion, now an element will get added when calling `setCount(_, for:)` if it was not in the set before.